### PR TITLE
K8s Demo - Deploying Microservice in k8s

### DIFF
--- a/kubernetes/configs/deployment.yaml
+++ b/kubernetes/configs/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80ß
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0

--- a/kubernetes/policy/custom.rego
+++ b/kubernetes/policy/custom.rego
@@ -1,0 +1,34 @@
+package user.kubernetes.ID001
+
+__rego_metadata__ := {
+    "id": "ID003",
+    "title": "Servide does not target Pod",
+    "severity": "CRITICAL",
+    "type": "Kubernetes Custom Check",
+    "description": "Service selector does not match any Pod label",
+}
+
+__rego_input__ := {
+    "combine": true,
+    "selector": [
+        {"type": "kubernetes"},
+    ],
+}
+
+deny[res] {
+    service := input[i].contents
+    service.kind == "Service"
+    value := service.spec.selector[key]
+    not match_label(key, value)
+
+	res := {
+		"filepath": input[i].path,
+		"msg": sprintf("Service '%s' selector does not match with any Pod label", [service.metadata.name]),
+	}
+}
+
+match_label(key, value) {
+	deployment := input[i].contents
+	deployment.kind == "Deployment"
+	deployment.spec.template.metadata.labels[key] == value
+}


### PR DESCRIPTION
# :rocket: Kubernetes Manifests

This PR adds the necessary k8s manifests to be able to deploy a Python microservice in the Kuberntes cluster. :trophy:

## :pencil: Type of change

- [x] :sparkles: New feature (non-breaking change which adds functionality)

# :microscope: How Has This Been Tested?

- [x] :house: Locally deploying the app in Kubernetes.

# :scroll: Checklist:

- [x] :art: My code follows the style guidelines of this project
- [x] :eyes: I have performed a self-review of my own code
- [x] :memo: I have commented my code, particularly in hard-to-understand areas
- [x] :books: I have made corresponding changes to the documentation
- [x] :warning: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :green_heart: New and existing unit tests pass locally with my changes